### PR TITLE
Clean up code style

### DIFF
--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -19,6 +19,7 @@ ACH_MISSING = 'missing'
 
 session = requests_html.HTMLSession()
 
+
 class PlayerProfile:
 
     '''
@@ -130,9 +131,9 @@ class PlayerProfile:
     @staticmethod
     def generate_hero_stats(html, hero_value, use_decimal=False):
         hero_category_list = html.find(f'div[data-category-id="{hero_value}"]')
-        if len(hero_category_list ) == 0:
+        if len(hero_category_list) == 0:
             return []
-        if len(hero_category_list ) != 1:
+        if len(hero_category_list) != 1:
             raise over_stats.errors.UnexpectedBehaviour('Found multiple heros for this value.')
         hero_stats = hero_category_list[0]
         cards = hero_stats.find('.card-stat-block')
@@ -201,7 +202,6 @@ class PlayerProfile:
             else:
                 return int(stat_value)
 
-
     '''
     Search for a <select> that matches the selectId. If no pageSection is provided we are going to search the whole page.
     If we find more than one matching <select> an exception will be thrown. 
@@ -238,7 +238,7 @@ class PlayerProfile:
     '''
     If _model is not populated or if force is tue, we will try to populate _model. Otherwise this method will be a noop.
     '''
-    def load_data(self, force = False):
+    def load_data(self, force=False):
         if force:
             seld._model = {}
         self.load_data_if_needed()
@@ -260,7 +260,7 @@ class PlayerProfile:
     Retrieve the comparison data avilable for the provided game mode.
     You can specify comparison type, and comparison hero to narrow down the return values.
     '''
-    def comparisons(self, mode, comparison_type = None, comparison_hero = None):
+    def comparisons(self, mode, comparison_type=None, comparison_hero=None):
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
         try:
@@ -298,7 +298,7 @@ class PlayerProfile:
     Retrieve the statistics data available for the provided game mode.
     You can provide a hero, category and stat name to narrow down the return value.
     '''
-    def stats(self, mode, hero = None, category = None, stat_name = None):
+    def stats(self, mode, hero=None, category=None, stat_name=None):
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
         try:
@@ -326,7 +326,7 @@ class PlayerProfile:
     Retrieve the available achievement data for this player. You can specify an achievement type or a list name to
     narrow down the returned value. The list_name parameter can be None, over_stats.ACH_EARNED or over_stats.ACH_MISSING. 
     '''
-    def achievements(self, achievement_type = None, list_name = None):
+    def achievements(self, achievement_type=None, list_name=None):
         try:
             if achievement_type is None:
                 return self.raw_data[ACHIEVEMENTS]
@@ -336,5 +336,3 @@ class PlayerProfile:
                 return self.raw_data[ACHIEVEMENTS][achievement_type][list_name]
         except KeyError:
             raise over_stats.errors.DataNotFound("Data not available")
-
-

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -198,13 +198,13 @@ class PlayerProfile:
                 return int(stat_value)
 
     @staticmethod
-    def getDictFromDropdown(selectId, pageSection):
+    def getDictFromDropdown(select_id, page_section):
         """
-        Search for a <select> that matches the selectId. If no pageSection is provided we are going to search the whole page.
+        Search for a <select> that matches the select_id. If no page_section is provided we are going to search the whole page.
         If we find more than one matching <select> an exception will be thrown.
         This method will then search for each <option> and it will return a dictionary that uses their text as the key.
         """
-        dropdown_list = pageSection.find(f'select[data-group-id="{selectId}"]')
+        dropdown_list = page_section.find(f'select[data-group-id="{select_id}"]')
         if len(dropdown_list) == 0:
             return {}
         if len(dropdown_list) > 1:

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -21,11 +21,9 @@ session = requests_html.HTMLSession()
 
 
 class PlayerProfile:
-
-    """
-    Constructor
-    """
     def __init__(self, battletag=None, platform=PLAT_PC, use_decimal=False):
+        """Create a new player profile."""
+
         if platform == PLAT_PC:
             try:
                 self._battletag = urllib.parse.quote(battletag.replace('#', '-'))
@@ -40,10 +38,7 @@ class PlayerProfile:
         self._use_decimal = use_decimal
         self.url = 'https://playoverwatch.com/en-us/career/' + platform + '/' + self._battletag
 
-    """
-    Internal methods
-    """
-
+    # Internal methods
     def get_html_for_mode(self, mode):
         """
         Used to retrieve the html element that contains all the data for competitive or quickplay.
@@ -101,12 +96,12 @@ class PlayerProfile:
                 achievements_dict[achievement_type] = achievement_dict
             self._model[ACHIEVEMENTS] = achievements_dict
 
-    """
-    Search the html element for divs containing the comparison stats.
-    The result will be a dictionary that uses a hero as it's key and the stat value as the value
-    """
     @staticmethod
     def generate_comparison_stats(html, comparison_value, use_decimal=False):
+        """
+        Search the html element for divs containing the comparison stats.
+        The result will be a dictionary that uses a hero as it's key and the stat value as the value
+        """
         comparison_list = html.find(f'div[data-category-id="{comparison_value}"]')
         if len(comparison_list) == 0:
             return []
@@ -123,13 +118,13 @@ class PlayerProfile:
             stat_dict[hero_name] = PlayerProfile.handle_stat_value(stat_value, use_decimal)
         return stat_dict
 
-    """
-    Search the html element for all divs containing the hero stat card. Each card will contain a list of
-    stats. The result will be a dictionary of stat categories names that link to a dictionary of stat names
-    and values.
-    """
     @staticmethod
     def generate_hero_stats(html, hero_value, use_decimal=False):
+        """
+        Search the html element for all divs containing the hero stat card. Each card will contain a list of
+        stats. The result will be a dictionary of stat categories names that link to a dictionary of stat names
+        and values.
+        """
         hero_category_list = html.find(f'div[data-category-id="{hero_value}"]')
         if len(hero_category_list) == 0:
             return []
@@ -153,13 +148,13 @@ class PlayerProfile:
             card_dict[card_title] = stat_dict
         return card_dict
 
-    """
-    Search the html element for a div that matches the achievement_type_value. This div will contain a list of achievements.
-    The return value will be a dictionary containing two lists, one for acquired and one for missing achievements. Each list
-    will contain the names of the respective achievements.
-    """
     @staticmethod
     def generate_achievement_list(html, achievement_type_value):
+        """
+        Search the html element for a div that matches the achievement_type_value. This div will contain a list of achievements.
+        The return value will be a dictionary containing two lists, one for acquired and one for missing achievements. Each list
+        will contain the names of the respective achievements.
+        """
         achievement_type_list = html.find(f'div[data-category-id="{achievement_type_value}"]')
         if len(achievement_type_list) == 0:
             return []
@@ -180,12 +175,12 @@ class PlayerProfile:
         stat_dict[ACH_MISSING] = missing_achievement
         return stat_dict
 
-    """
-    The values retrieved from the html is a string that represents different types of value types.
-    This method will handle converting those strings into their appropriate value
-    """
     @staticmethod
     def handle_stat_value(stat_value, use_decimal=False):
+        """
+        The values retrieved from the html is a string that represents different types of value types.
+        This method will handle converting those strings into their appropriate value
+        """
         if '--' == stat_value or ':' in stat_value:
             return stat_value
         elif '%' in stat_value:
@@ -202,13 +197,13 @@ class PlayerProfile:
             else:
                 return int(stat_value)
 
-    """
-    Search for a <select> that matches the selectId. If no pageSection is provided we are going to search the whole page.
-    If we find more than one matching <select> an exception will be thrown. 
-    This method will then search for each <option> and it will return a dictionary that uses their text as the key.
-    """
     @staticmethod
     def getDictFromDropdown(selectId, pageSection):
+        """
+        Search for a <select> that matches the selectId. If no pageSection is provided we are going to search the whole page.
+        If we find more than one matching <select> an exception will be thrown.
+        This method will then search for each <option> and it will return a dictionary that uses their text as the key.
+        """
         dropdownList = pageSection.find(f'select[data-group-id="{selectId}"]')
         if len(dropdownList) == 0:
             return {}
@@ -222,9 +217,7 @@ class PlayerProfile:
             optionDict[text] = value
         return optionDict
 
-    """
-    Public APIs
-    """
+    # Public APIs
 
     @property
     def raw_data(self):
@@ -235,32 +228,32 @@ class PlayerProfile:
         self.load_data_if_needed()
         return self._model
 
-    """
-    If _model is not populated or if force is tue, we will try to populate _model. Otherwise this method will be a noop.
-    """
     def load_data(self, force=False):
+        """
+        If _model is not populated or if force is tue, we will try to populate _model. Otherwise this method will be a noop.
+        """
         if force:
             seld._model = {}
         self.load_data_if_needed()
 
-    """
-    Get a list of comparison types available for this game mode
-    """
     def comparison_types(self, mode):
+        """
+        Get a list of comparison types available for this game mode
+        """
         return list(self.raw_data[mode][COMPARISON].keys())
 
-    """
-    Get a list of available heroes for this combination of comparison type and game mode
-    """
     def comparison_heroes(self, mode, comparison_type):
+        """
+        Get a list of available heroes for this combination of comparison type and game mode
+        """
         return list(self.raw_data[mode][COMPARISON][comparison_type].keys())
 
-    """
-    Get comparison data
-    Retrieve the comparison data avilable for the provided game mode.
-    You can specify comparison type, and comparison hero to narrow down the return values.
-    """
     def comparisons(self, mode, comparison_type=None, comparison_hero=None):
+        """
+        Get comparison data
+        Retrieve the comparison data avilable for the provided game mode.
+        You can specify comparison type, and comparison hero to narrow down the return values.
+        """
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
         try:
@@ -275,30 +268,30 @@ class PlayerProfile:
         except KeyError:
             raise over_stats.errors.DataNotFound("Data not available")
 
-    """
-    Get a list of available heroes to get stats from for the provided game mode.
-    """
     def stat_heroes(self, mode):
+        """
+        Get a list of available heroes to get stats from for the provided game mode.
+        """
         return list(self.raw_data[mode][STATS].keys())
 
-    """
-    Get a list of available stat categories for the requested hero
-    """
     def stat_categories(self, mode, hero):
+        """
+        Get a list of available stat categories for the requested hero
+        """
         return list(self.raw_data[mode][STATS][hero].keys())
 
-    """
-    Get a list of available stat names for the requested game mode, hero name and stat category
-    """
     def stat_names(self, mode, hero, category):
+        """
+        Get a list of available stat names for the requested game mode, hero name and stat category
+        """
         return list(self.raw_data[mode][STATS][hero][category].keys())
 
-    """
-    Get stats data
-    Retrieve the statistics data available for the provided game mode.
-    You can provide a hero, category and stat name to narrow down the return value.
-    """
     def stats(self, mode, hero=None, category=None, stat_name=None):
+        """
+        Get stats data
+        Retrieve the statistics data available for the provided game mode.
+        You can provide a hero, category and stat name to narrow down the return value.
+        """
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
         try:
@@ -315,18 +308,18 @@ class PlayerProfile:
         except KeyError:
             raise over_stats.errors.DataNotFound("Data not available")
 
-    """
-    Get a list of available achievement types.
-    """
     def achievement_types(self):
+        """
+        Get a list of available achievement types.
+        """
         return list(self.raw_data[ACHIEVEMENTS].keys())
 
-    """
-    Get achievement data
-    Retrieve the available achievement data for this player. You can specify an achievement type or a list name to
-    narrow down the returned value. The list_name parameter can be None, over_stats.ACH_EARNED or over_stats.ACH_MISSING. 
-    """
     def achievements(self, achievement_type=None, list_name=None):
+        """
+        Get achievement data
+        Retrieve the available achievement data for this player. You can specify an achievement type or a list name to
+        narrow down the returned value. The list_name parameter can be None, over_stats.ACH_EARNED or over_stats.ACH_MISSING.
+        """
         try:
             if achievement_type is None:
                 return self.raw_data[ACHIEVEMENTS]

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -185,9 +185,9 @@ class PlayerProfile:
             return stat_value
         elif '%' in stat_value:
             if use_decimal:
-                return Decimal(str(float(stat_value.replace("%", ""))/(100.0)))
+                return Decimal(str(float(stat_value.replace("%", "")) / 100.0))
             else:
-                return float(stat_value.replace("%", ""))/(100.0)
+                return float(stat_value.replace("%", "")) / 100.0
         elif ' ' in stat_value:
             return stat_value.split(" ")
         else:

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -42,7 +42,7 @@ class PlayerProfile:
     '''
     Internal methods
     '''
-        
+
     def get_html_for_mode(self, mode):
         '''
         Used to retrieve the html element that contains all the data for competitive or quickplay.
@@ -52,7 +52,7 @@ class PlayerProfile:
             raise over_stats.errors.PlayerNotFound(f'Mode "{mode}" was not found. There is no data for this player')
         if len(html) != 1:
             raise over_stats.errors.UnexpectedBehaviour('Finding the element for this game mode returned more than 1 element')
-        
+
         return html[0]
 
     def load_data_if_needed(self):
@@ -62,7 +62,7 @@ class PlayerProfile:
         the _model variable.
 
         '''
-        if self._model == None:
+        if self._model is None:
             self._model = {}
             self._r = session.get(self.url)
             # We are assuming that OW will not have any other game modes other than competitive and quickplay. 
@@ -70,7 +70,7 @@ class PlayerProfile:
                 # now get the html content that belongs to the current game mode
                 html_mode = self.get_html_for_mode(mode)
                 mode_dict = {}
-                
+
                 # now retrieve the dictionary for all the different comparisons available, they will be something
                 # like 'Games Won', 'Time Played', 'Weapon Accuracy', etc
                 comparison_dict = {}
@@ -79,7 +79,7 @@ class PlayerProfile:
                     comparison_stats = self.generate_comparison_stats(html_mode, comp_value, self._use_decimal)
                     comparison_dict[comp_name] = comparison_stats
                 mode_dict[COMPARISON] = comparison_dict
-                
+
                 # Now we are going to parse the career stat section
                 hero_stat_dict = {}
                 # Generate the dictionary for the hero stats
@@ -89,7 +89,7 @@ class PlayerProfile:
                     hero_stats = self.generate_hero_stats(html_mode, heroe_value, self._use_decimal)
                     hero_stat_dict[heroe_name] = hero_stats
                 mode_dict[STATS] = hero_stat_dict
-                
+
                 self._model[mode] = mode_dict
             achievements_dict = {}
             # Now extract the achievements
@@ -99,7 +99,7 @@ class PlayerProfile:
                 achievement_dict = self.generate_achievement_list(self._r.html, achievement_type_value)
                 achievements_dict[achievement_type] = achievement_dict
             self._model[ACHIEVEMENTS] = achievements_dict
-    
+
     '''
     Search the html element for divs containing the comparison stats.
     The result will be a dictionary that uses a hero as it's key and the stat value as the value
@@ -254,7 +254,7 @@ class PlayerProfile:
     '''
     def comparison_heroes(self, mode, comparison_type):
         return list(self.raw_data[mode][COMPARISON][comparison_type].keys())
-   
+
     '''
     Get comparison data
     Retrieve the comparison data avilable for the provided game mode.
@@ -264,11 +264,11 @@ class PlayerProfile:
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
         try:
-            if comparison_type == None and comparison_hero == None:
+            if comparison_type is None and comparison_hero is None:
                 return self.raw_data[mode][COMPARISON]
-            elif comparison_type != None and comparison_hero == None:
+            elif comparison_type is not None and comparison_hero is None:
                 return self.raw_data[mode][COMPARISON][comparison_type]
-            elif comparison_type != None and comparison_hero != None:
+            elif comparison_type is not None and comparison_hero is not None:
                 return self.raw_data[mode][COMPARISON][comparison_type][comparison_hero]
             else:
                 raise over_stats.errors.InvalidArgument(f'Combination of comparison_type="{comparison_type}", comparison_hero="{comparison_hero}" is not valid')
@@ -280,13 +280,13 @@ class PlayerProfile:
     '''
     def stat_heroes(self, mode):
         return list(self.raw_data[mode][STATS].keys())
- 
+
     '''
     Get a list of available stat categories for the requested hero
     '''
     def stat_categories(self, mode, hero):
         return list(self.raw_data[mode][STATS][hero].keys())
-    
+
     '''
     Get a list of available stat names for the requested game mode, hero name and stat category
     '''
@@ -302,13 +302,13 @@ class PlayerProfile:
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
         try:
-            if hero == None and category == None and stat_name == None:
+            if hero is None and category is None and stat_name is None:
                 return self.raw_data[mode][STATS]
-            elif hero != None and category == None and stat_name == None:
+            elif hero is not None and category is None and stat_name is None:
                 return self.raw_data[mode][STATS][hero]
-            elif hero != None and category != None and stat_name == None:
+            elif hero is not None and category is not None and stat_name is None:
                 return self.raw_data[mode][STATS][hero][category]
-            elif hero != None and category != None and stat_name != None:
+            elif hero is not None and category is not None and stat_name is not None:
                 return self.raw_data[mode][STATS][hero][category][stat_name]
             else:
                 raise over_stats.errors.InvalidArgument(f'Combination of hero="{hero}", category="{category}" and stat_name="{stat_name}" is not valid')
@@ -328,9 +328,9 @@ class PlayerProfile:
     '''
     def achievements(self, achievement_type = None, list_name = None):
         try:
-            if achievement_type == None:
+            if achievement_type is None:
                 return self.raw_data[ACHIEVEMENTS]
-            elif list_name == None:
+            elif list_name is None:
                 return self.raw_data[ACHIEVEMENTS][achievement_type]
             else:
                 return self.raw_data[ACHIEVEMENTS][achievement_type][list_name]

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -204,18 +204,18 @@ class PlayerProfile:
         If we find more than one matching <select> an exception will be thrown.
         This method will then search for each <option> and it will return a dictionary that uses their text as the key.
         """
-        dropdownList = pageSection.find(f'select[data-group-id="{selectId}"]')
-        if len(dropdownList) == 0:
+        dropdown_list = pageSection.find(f'select[data-group-id="{selectId}"]')
+        if len(dropdown_list) == 0:
             return {}
-        if len(dropdownList) > 1:
+        if len(dropdown_list) > 1:
             raise over_stats.errors.UnexpectedBehaviour('Found multiple dropdowns found.')
-        optionList = dropdownList[0].find('option')
-        optionDict = {}
-        for option in optionList:
+        option_list = dropdown_list[0].find('option')
+        option_dict = {}
+        for option in option_list:
             text = option.text
             value = option.attrs['value']
-            optionDict[text] = value
-        return optionDict
+            option_dict[text] = value
+        return option_dict
 
     # Public APIs
 

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -1,5 +1,6 @@
 from decimal import *
 import urllib
+
 import requests_html
 
 import over_stats.errors

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -70,7 +70,7 @@ class PlayerProfile:
                 # now retrieve the dictionary for all the different comparisons available, they will be something
                 # like 'Games Won', 'Time Played', 'Weapon Accuracy', etc
                 comparison_dict = {}
-                comparisons = self.getDictFromDropdown(COMPARISON, html_mode)
+                comparisons = self.get_dict_from_dropdown(COMPARISON, html_mode)
                 for comp_name, comp_value in comparisons.items():
                     comparison_stats = self.generate_comparison_stats(html_mode, comp_value, self._use_decimal)
                     comparison_dict[comp_name] = comparison_stats
@@ -79,7 +79,7 @@ class PlayerProfile:
                 # Now we are going to parse the career stat section
                 hero_stat_dict = {}
                 # Generate the dictionary for the hero stats
-                heroes = self.getDictFromDropdown(STATS, html_mode)
+                heroes = self.get_dict_from_dropdown(STATS, html_mode)
                 # Now generate a dictionary using the hero name as the dictionary key
                 for heroe_name, heroe_value in heroes.items():
                     hero_stats = self.generate_hero_stats(html_mode, heroe_value, self._use_decimal)
@@ -89,7 +89,7 @@ class PlayerProfile:
                 self._model[mode] = mode_dict
             achievements_dict = {}
             # Now extract the achievements
-            achievements = self.getDictFromDropdown(ACHIEVEMENTS, self._r.html)
+            achievements = self.get_dict_from_dropdown(ACHIEVEMENTS, self._r.html)
             # The achievement_type will be something like 'Offense', 'Defense', 'Tank', etc
             for achievement_type, achievement_type_value in achievements.items():
                 achievement_dict = self.generate_achievement_list(self._r.html, achievement_type_value)
@@ -198,7 +198,7 @@ class PlayerProfile:
                 return int(stat_value)
 
     @staticmethod
-    def getDictFromDropdown(select_id, page_section):
+    def get_dict_from_dropdown(select_id, page_section):
         """
         Search for a <select> that matches the select_id. If no page_section is provided we are going to search the whole page.
         If we find more than one matching <select> an exception will be thrown.

--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -22,9 +22,9 @@ session = requests_html.HTMLSession()
 
 class PlayerProfile:
 
-    '''
+    """
     Constructor
-    '''
+    """
     def __init__(self, battletag=None, platform=PLAT_PC, use_decimal=False):
         if platform == PLAT_PC:
             try:
@@ -40,14 +40,14 @@ class PlayerProfile:
         self._use_decimal = use_decimal
         self.url = 'https://playoverwatch.com/en-us/career/' + platform + '/' + self._battletag
 
-    '''
+    """
     Internal methods
-    '''
+    """
 
     def get_html_for_mode(self, mode):
-        '''
+        """
         Used to retrieve the html element that contains all the data for competitive or quickplay.
-        '''
+        """
         html = self._r.html.find(f'div[id="{mode}"]')
         if len(html) == 0:
             raise over_stats.errors.PlayerNotFound(f'Mode "{mode}" was not found. There is no data for this player')
@@ -57,12 +57,12 @@ class PlayerProfile:
         return html[0]
 
     def load_data_if_needed(self):
-        '''
+        """
         This method will check if the _model variable holds any data, and if it does then return it. If it is empty
         then a network request will be made to download the player profile data and it will be parsed and stored in
         the _model variable.
 
-        '''
+        """
         if self._model is None:
             self._model = {}
             self._r = session.get(self.url)
@@ -101,10 +101,10 @@ class PlayerProfile:
                 achievements_dict[achievement_type] = achievement_dict
             self._model[ACHIEVEMENTS] = achievements_dict
 
-    '''
+    """
     Search the html element for divs containing the comparison stats.
     The result will be a dictionary that uses a hero as it's key and the stat value as the value
-    '''
+    """
     @staticmethod
     def generate_comparison_stats(html, comparison_value, use_decimal=False):
         comparison_list = html.find(f'div[data-category-id="{comparison_value}"]')
@@ -123,11 +123,11 @@ class PlayerProfile:
             stat_dict[hero_name] = PlayerProfile.handle_stat_value(stat_value, use_decimal)
         return stat_dict
 
-    '''
+    """
     Search the html element for all divs containing the hero stat card. Each card will contain a list of
     stats. The result will be a dictionary of stat categories names that link to a dictionary of stat names
     and values.
-    '''
+    """
     @staticmethod
     def generate_hero_stats(html, hero_value, use_decimal=False):
         hero_category_list = html.find(f'div[data-category-id="{hero_value}"]')
@@ -153,11 +153,11 @@ class PlayerProfile:
             card_dict[card_title] = stat_dict
         return card_dict
 
-    '''
+    """
     Search the html element for a div that matches the achievement_type_value. This div will contain a list of achievements.
     The return value will be a dictionary containing two lists, one for acquired and one for missing achievements. Each list
     will contain the names of the respective achievements.
-    '''
+    """
     @staticmethod
     def generate_achievement_list(html, achievement_type_value):
         achievement_type_list = html.find(f'div[data-category-id="{achievement_type_value}"]')
@@ -180,10 +180,10 @@ class PlayerProfile:
         stat_dict[ACH_MISSING] = missing_achievement
         return stat_dict
 
-    '''
+    """
     The values retrieved from the html is a string that represents different types of value types.
     This method will handle converting those strings into their appropriate value
-    '''
+    """
     @staticmethod
     def handle_stat_value(stat_value, use_decimal=False):
         if '--' == stat_value or ':' in stat_value:
@@ -202,11 +202,11 @@ class PlayerProfile:
             else:
                 return int(stat_value)
 
-    '''
+    """
     Search for a <select> that matches the selectId. If no pageSection is provided we are going to search the whole page.
     If we find more than one matching <select> an exception will be thrown. 
     This method will then search for each <option> and it will return a dictionary that uses their text as the key.
-    '''
+    """
     @staticmethod
     def getDictFromDropdown(selectId, pageSection):
         dropdownList = pageSection.find(f'select[data-group-id="{selectId}"]')
@@ -222,44 +222,44 @@ class PlayerProfile:
             optionDict[text] = value
         return optionDict
 
-    '''
+    """
     Public APIs
-    '''
+    """
 
     @property
     def raw_data(self):
-        '''
+        """
         Return the content of _model. If _model is still empty then a load_data_if_needed() will ensure to make a request 
         to populate it.
-        '''
+        """
         self.load_data_if_needed()
         return self._model
 
-    '''
+    """
     If _model is not populated or if force is tue, we will try to populate _model. Otherwise this method will be a noop.
-    '''
+    """
     def load_data(self, force=False):
         if force:
             seld._model = {}
         self.load_data_if_needed()
 
-    '''
+    """
     Get a list of comparison types available for this game mode
-    '''
+    """
     def comparison_types(self, mode):
         return list(self.raw_data[mode][COMPARISON].keys())
 
-    '''
+    """
     Get a list of available heroes for this combination of comparison type and game mode
-    '''
+    """
     def comparison_heroes(self, mode, comparison_type):
         return list(self.raw_data[mode][COMPARISON][comparison_type].keys())
 
-    '''
+    """
     Get comparison data
     Retrieve the comparison data avilable for the provided game mode.
     You can specify comparison type, and comparison hero to narrow down the return values.
-    '''
+    """
     def comparisons(self, mode, comparison_type=None, comparison_hero=None):
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
@@ -275,29 +275,29 @@ class PlayerProfile:
         except KeyError:
             raise over_stats.errors.DataNotFound("Data not available")
 
-    '''
+    """
     Get a list of available heroes to get stats from for the provided game mode.
-    '''
+    """
     def stat_heroes(self, mode):
         return list(self.raw_data[mode][STATS].keys())
 
-    '''
+    """
     Get a list of available stat categories for the requested hero
-    '''
+    """
     def stat_categories(self, mode, hero):
         return list(self.raw_data[mode][STATS][hero].keys())
 
-    '''
+    """
     Get a list of available stat names for the requested game mode, hero name and stat category
-    '''
+    """
     def stat_names(self, mode, hero, category):
         return list(self.raw_data[mode][STATS][hero][category].keys())
 
-    '''
+    """
     Get stats data
     Retrieve the statistics data available for the provided game mode.
     You can provide a hero, category and stat name to narrow down the return value.
-    '''
+    """
     def stats(self, mode, hero=None, category=None, stat_name=None):
         if mode not in MODES:
             raise over_stats.errors.InvalidArgument(f'mode="{mode}" is invalid')
@@ -315,17 +315,17 @@ class PlayerProfile:
         except KeyError:
             raise over_stats.errors.DataNotFound("Data not available")
 
-    '''
+    """
     Get a list of available achievement types.
-    '''
+    """
     def achievement_types(self):
         return list(self.raw_data[ACHIEVEMENTS].keys())
 
-    '''
+    """
     Get achievement data
     Retrieve the available achievement data for this player. You can specify an achievement type or a list name to
     narrow down the returned value. The list_name parameter can be None, over_stats.ACH_EARNED or over_stats.ACH_MISSING. 
-    '''
+    """
     def achievements(self, achievement_type=None, list_name=None):
         try:
             if achievement_type is None:

--- a/over_stats/errors.py
+++ b/over_stats/errors.py
@@ -1,11 +1,14 @@
 class InvalidArgument(Exception):
     pass
 
+
 class UnexpectedBehaviour(Exception):
     pass
 
+
 class PlayerNotFound(Exception):
     pass
+
 
 class DataNotFound(Exception):
     pass


### PR DESCRIPTION
Fix code style deviations from PEP-8 and PEP-257.

- Make variable, argument, and function names lowercase
- Uses `is` / `is not` for comparison with `None`
- Fix docstrings
- Standardizes blank lines
- Removes excess whitespace
- Remove redundant parentheses