### PR TITLE
Fix urllib.parse import

### DIFF
--- a/over_stats/__init__.py
+++ b/over_stats/__init__.py
@@ -1,5 +1,5 @@
 from decimal import *
-import urllib
+import urllib.parse
 import requests_html
 
 import over_stats.errors


### PR DESCRIPTION
The function `urllib.parse.quote` is being used, and while `urllib` is imported, the module `urllib.parse` is not.